### PR TITLE
Add container settings

### DIFF
--- a/spring-cloud-dataflow-admin-yarn-dist/src/main/resources/config/servers.yml
+++ b/spring-cloud-dataflow-admin-yarn-dist/src/main/resources/config/servers.yml
@@ -9,4 +9,22 @@ spring:
   redis:
     port: 6379
     host: localhost
-
+#dataflow:
+#  yarn:
+#    app:
+#      streamappmaster:
+#        memory: 512m
+#        virtualCores: 1
+#      streamcontainer:
+#        priority: 5
+#        memory: 256m
+#        virtualCores: 1
+#        javaOpts: "-Xms64m -Xmx256m"
+#      taskappmaster:
+#        memory: 512m
+#        virtualCores: 1
+#      taskcontainer:
+#        priority: 10
+#        memory: 256m
+#        virtualCores: 1
+#        javaOpts: "-Xms64m -Xmx256m"

--- a/spring-cloud-dataflow-admin-yarn/src/main/resources/stream.yml
+++ b/spring-cloud-dataflow-admin-yarn/src/main/resources/stream.yml
@@ -23,5 +23,10 @@ spring:
         arguments:
           -Dspring.config.location: servers.yml
         archiveFile: spring-cloud-dataflow-yarn-streamappmaster-${spring.cloud.dataflow.yarn.version}.jar
+      localizer:
+        patterns:
+          - "spring-cloud-dataflow-yarn-streamappmaster-*.jar"
+          - "servers.yml"
       resource:
-        memory: 1g
+        memory: ${dataflow.yarn.app.streamappmaster.memory:512m}
+        virtualCores: ${dataflow.yarn.app.streamappmaster.virtualCores:1}

--- a/spring-cloud-dataflow-admin-yarn/src/main/resources/task.yml
+++ b/spring-cloud-dataflow-admin-yarn/src/main/resources/task.yml
@@ -19,8 +19,15 @@ spring:
         - "file:${dataflow.yarn.app.container.path:lib}/spring-cloud-dataflow-yarn-taskcontainer-*.jar"
         - "file:${dataflow.yarn.app.config.path:config}/servers.yml"
       launchcontext:
+        options:
+          - ${dataflow.yarn.app.taskappmaster.javaOpts:}
         arguments:
           -Dspring.config.location: servers.yml
         archiveFile: spring-cloud-dataflow-yarn-taskappmaster-${spring.cloud.dataflow.yarn.version}.jar
+      localizer:
+        patterns:
+          - "spring-cloud-dataflow-yarn-taskappmaster-*.jar"
+          - "servers.yml"
       resource:
-        memory: 1g
+        memory: ${dataflow.yarn.app.taskappmaster.memory:512m}
+        virtualCores: ${dataflow.yarn.app.taskappmaster.virtualCores:1}

--- a/spring-cloud-dataflow-yarn-streamappmaster/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-yarn-streamappmaster/src/main/resources/application.yml
@@ -28,10 +28,12 @@ spring:
         clusters:
           module-template:
             resource:
-              priority: 10
-              memory: 64
-              virtualCores: 1
+              priority: ${dataflow.yarn.app.streamcontainer.priority:5}
+              memory: ${dataflow.yarn.app.streamcontainer.memory:256m}
+              virtualCores: ${dataflow.yarn.app.streamcontainer.virtualCores:1}
             launchcontext:
+              options:
+                - ${dataflow.yarn.app.streamcontainer.javaOpts:}
               arguments:
                 -Dserver.port: 0
                 -Dspring.jmx.enabled: false              

--- a/spring-cloud-dataflow-yarn-taskappmaster/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-yarn-taskappmaster/src/main/resources/application.yml
@@ -20,14 +20,15 @@ spring:
       appmasterClass: org.springframework.cloud.dataflow.yarn.taskappmaster.DataFlowTaskAppmaster
       localizer:
         patterns:
-          - "spring-cloud-dataflow-yarn-container-*.jar"
           - "spring-cloud-dataflow-yarn-taskcontainer-*.jar"
           - "servers.yml"
       resource:
-        priority: 10
-        memory: 64
-        virtualCores: 1
+        priority: ${dataflow.yarn.app.taskcontainer.priority:10}
+        memory: ${dataflow.yarn.app.taskcontainer.memory:256m}
+        virtualCores: ${dataflow.yarn.app.taskcontainer.virtualCores:1}
       launchcontext:
+        options:
+          - ${dataflow.yarn.app.taskcontainer.javaOpts:}
         arguments:
           -Dserver.port: 0
           -Dspring.jmx.enabled: false              


### PR DESCRIPTION
- Fixes spring-cloud/spring-cloud-dataflow-admin-yarn#17
- Add resource priority, cpu and mem settings.
- Add javaOpts
- Make all those configurable via servers.yml
- For tasks, these settings can be configured during
  a deployment after shell is starting do support passing
  in deployment properties.
- For streams all settings are coming from servers.yml because
  we still have limitation to be able to run only one app
  at a time. That work is done in #2 which needs some tweaks to
  how module deployer spi works.
