### PR TITLE
Workaround finding correct local address

### DIFF
--- a/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/EmbeddedAppmasterTrackService.java
+++ b/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/EmbeddedAppmasterTrackService.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.yarn.streamappmaster;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext;
+import org.springframework.boot.context.embedded.EmbeddedServletContainer;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.yarn.am.AppmasterTrackService;
+
+/**
+ * A {@link AppmasterTrackService} which delegates to an
+ * {@link EmbeddedServletContainer} to find a configured port whether that is
+ * hard coded or set to be picked up automatically.
+ * <p>
+ * {@link EmbeddedServletContainer} is received from an {@link ApplicationEvent}
+ * send by boot to notify existence of
+ * {@link AnnotationConfigEmbeddedWebApplicationContext}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class EmbeddedAppmasterTrackService implements AppmasterTrackService, ApplicationListener<ApplicationEvent> {
+
+	private final static Log log = LogFactory.getLog(EmbeddedAppmasterTrackService.class);
+
+	private final static long DEFAULT_WAIT_TIME = 60000;
+
+	private EmbeddedServletContainer embeddedServletContainer;
+
+	private long waitTime;
+
+	/**
+	 * Instantiates a new embedded appmaster track service with
+	 * default wait time of 60 seconds.
+	 */
+	public EmbeddedAppmasterTrackService() {
+		this(DEFAULT_WAIT_TIME);
+	}
+
+	/**
+	 * Instantiates a new embedded appmaster track service.
+	 *
+	 * @param waitTime the wait time in millis
+	 */
+	public EmbeddedAppmasterTrackService(long waitTime) {
+		this.waitTime = waitTime;
+	}
+
+	@Override
+	public String getTrackUrl() {
+		if (embeddedServletContainer == null) {
+			log.warn("Request for track url but unable to delegate because embeddedServletContainer is not set, returning null.");
+			return null;
+		}
+		long now = System.currentTimeMillis();
+		while(now + waitTime > System.currentTimeMillis()) {
+			int port = embeddedServletContainer.getPort();
+			if (log.isDebugEnabled()) {
+				log.debug("Polling port from EmbeddedServletContainer port=" + port);
+			}
+			if (port > 0) {
+				String url = "http://" + getDefaultAddress() + ":" + port;
+				log.info("Giving out track url as " + url);
+				return url;
+			}
+			try {
+				Thread.sleep(1000);
+			} catch (InterruptedException e) {
+			}
+		}
+		log.warn("Waited " + (System.currentTimeMillis()-now) + " millis for embeddedServletContainer port, returning null.");
+		return null;
+	}
+
+	@Override
+	public void onApplicationEvent(ApplicationEvent event) {
+		Object source = event.getSource();
+		if (source instanceof AnnotationConfigEmbeddedWebApplicationContext) {
+			embeddedServletContainer = ((AnnotationConfigEmbeddedWebApplicationContext) source)
+					.getEmbeddedServletContainer();
+		}
+	}
+
+	/**
+	 * Sets the max time waiting for embedded container port.
+	 *
+	 * @param waitTime the new wait time in millis
+	 */
+	public void setWaitTime(long waitTime) {
+		this.waitTime = waitTime;
+	}
+
+	private static String getDefaultAddress() {
+		Enumeration<NetworkInterface> nets;
+		try {
+			nets = NetworkInterface.getNetworkInterfaces();
+		} catch (SocketException e) {
+			return null;
+		}
+		NetworkInterface netinf;
+		while (nets.hasMoreElements()) {
+			netinf = nets.nextElement();
+			boolean skip = false;
+			try {
+				skip = netinf.isPointToPoint();
+			} catch (SocketException e) {
+				skip = true;
+			}
+			if (skip) {
+				continue;
+			}
+			Enumeration<InetAddress> addresses = netinf.getInetAddresses();
+			while (addresses.hasMoreElements()) {
+				InetAddress address = addresses.nextElement();
+				if (!address.isAnyLocalAddress() && !address.isMulticastAddress() && !(address instanceof Inet6Address)) {
+					return address.getHostAddress();
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/StreamAppmasterApplication.java
+++ b/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/StreamAppmasterApplication.java
@@ -18,6 +18,10 @@ package org.springframework.cloud.dataflow.yarn.streamappmaster;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.yarn.YarnSystemConstants;
+import org.springframework.yarn.am.AppmasterTrackService;
 
 /**
  * Yarn application bootstrapping appmaster.
@@ -27,6 +31,15 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  */
 @SpringBootApplication
 public class StreamAppmasterApplication {
+
+	@Configuration
+	public static class Config {
+
+		@Bean(name=YarnSystemConstants.DEFAULT_ID_AMTRACKSERVICE)
+		public AppmasterTrackService appmasterTrackService() {
+			return new EmbeddedAppmasterTrackService();
+		}
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(StreamAppmasterApplication.class, args);

--- a/spring-cloud-dataflow-yarn-taskappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/taskappmaster/EmbeddedAppmasterTrackService.java
+++ b/spring-cloud-dataflow-yarn-taskappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/taskappmaster/EmbeddedAppmasterTrackService.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.yarn.taskappmaster;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext;
+import org.springframework.boot.context.embedded.EmbeddedServletContainer;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.yarn.am.AppmasterTrackService;
+
+/**
+ * A {@link AppmasterTrackService} which delegates to an
+ * {@link EmbeddedServletContainer} to find a configured port whether that is
+ * hard coded or set to be picked up automatically.
+ * <p>
+ * {@link EmbeddedServletContainer} is received from an {@link ApplicationEvent}
+ * send by boot to notify existence of
+ * {@link AnnotationConfigEmbeddedWebApplicationContext}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class EmbeddedAppmasterTrackService implements AppmasterTrackService, ApplicationListener<ApplicationEvent> {
+
+	private final static Log log = LogFactory.getLog(EmbeddedAppmasterTrackService.class);
+
+	private final static long DEFAULT_WAIT_TIME = 60000;
+
+	private EmbeddedServletContainer embeddedServletContainer;
+
+	private long waitTime;
+
+	/**
+	 * Instantiates a new embedded appmaster track service with
+	 * default wait time of 60 seconds.
+	 */
+	public EmbeddedAppmasterTrackService() {
+		this(DEFAULT_WAIT_TIME);
+	}
+
+	/**
+	 * Instantiates a new embedded appmaster track service.
+	 *
+	 * @param waitTime the wait time in millis
+	 */
+	public EmbeddedAppmasterTrackService(long waitTime) {
+		this.waitTime = waitTime;
+	}
+
+	@Override
+	public String getTrackUrl() {
+		if (embeddedServletContainer == null) {
+			log.warn("Request for track url but unable to delegate because embeddedServletContainer is not set, returning null.");
+			return null;
+		}
+		long now = System.currentTimeMillis();
+		while(now + waitTime > System.currentTimeMillis()) {
+			int port = embeddedServletContainer.getPort();
+			if (log.isDebugEnabled()) {
+				log.debug("Polling port from EmbeddedServletContainer port=" + port);
+			}
+			if (port > 0) {
+				String url = "http://" + getDefaultAddress() + ":" + port;
+				log.info("Giving out track url as " + url);
+				return url;
+			}
+			try {
+				Thread.sleep(1000);
+			} catch (InterruptedException e) {
+			}
+		}
+		log.warn("Waited " + (System.currentTimeMillis()-now) + " millis for embeddedServletContainer port, returning null.");
+		return null;
+	}
+
+	@Override
+	public void onApplicationEvent(ApplicationEvent event) {
+		Object source = event.getSource();
+		if (source instanceof AnnotationConfigEmbeddedWebApplicationContext) {
+			embeddedServletContainer = ((AnnotationConfigEmbeddedWebApplicationContext) source)
+					.getEmbeddedServletContainer();
+		}
+	}
+
+	/**
+	 * Sets the max time waiting for embedded container port.
+	 *
+	 * @param waitTime the new wait time in millis
+	 */
+	public void setWaitTime(long waitTime) {
+		this.waitTime = waitTime;
+	}
+
+	private static String getDefaultAddress() {
+		Enumeration<NetworkInterface> nets;
+		try {
+			nets = NetworkInterface.getNetworkInterfaces();
+		} catch (SocketException e) {
+			return null;
+		}
+		NetworkInterface netinf;
+		while (nets.hasMoreElements()) {
+			netinf = nets.nextElement();
+			boolean skip = false;
+			try {
+				skip = netinf.isPointToPoint();
+			} catch (SocketException e) {
+				skip = true;
+			}
+			if (skip) {
+				continue;
+			}
+			Enumeration<InetAddress> addresses = netinf.getInetAddresses();
+			while (addresses.hasMoreElements()) {
+				InetAddress address = addresses.nextElement();
+				if (!address.isAnyLocalAddress() && !address.isMulticastAddress() && !(address instanceof Inet6Address)) {
+					return address.getHostAddress();
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/spring-cloud-dataflow-yarn-taskappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/taskappmaster/TaskAppmasterApplication.java
+++ b/spring-cloud-dataflow-yarn-taskappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/taskappmaster/TaskAppmasterApplication.java
@@ -20,6 +20,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.dataflow.yarn.common.DataflowModuleYarnProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.yarn.YarnSystemConstants;
+import org.springframework.yarn.am.AppmasterTrackService;
 
 /**
  * Yarn application bootstrapping appmaster.
@@ -30,6 +34,15 @@ import org.springframework.cloud.dataflow.yarn.common.DataflowModuleYarnProperti
 @SpringBootApplication
 @EnableConfigurationProperties({ DataflowModuleYarnProperties.class })
 public class TaskAppmasterApplication {
+
+	@Configuration
+	public static class Config {
+
+		@Bean(name=YarnSystemConstants.DEFAULT_ID_AMTRACKSERVICE)
+		public AppmasterTrackService appmasterTrackService() {
+			return new EmbeddedAppmasterTrackService();
+		}
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(TaskAppmasterApplication.class, args);


### PR DESCRIPTION
- This fixes spring-cloud/spring-cloud-dataflow-admin-yarn#23 and closes spring-cloud/spring-cloud-dataflow-admin-yarn#24
- Until we get SHDP-546 fixed, override yarnAmTrackservice bean
  for appmasters by re-implementing EmbeddedAppmasterTrackService
  from yarn boot to be able to use custom function favour of
  NetworkUtils.getDefaultAddress(). This bean is responsible for
  registering embedded boot endpoint address which is then used
  to communicated with appmaster.
