### PR TITLE
Quoting and escaping commands

### DIFF
--- a/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/DefaultYarnCloudAppService.java
+++ b/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/DefaultYarnCloudAppService.java
@@ -112,7 +112,14 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService, Initiali
 
 		int i = 0;
 		for (Map.Entry<String, String> entry : definitionParameters.entrySet()) {
-			extraProperties.put("containerArg" + i++, entry.getKey() + "=" + entry.getValue());
+			String value = entry.getValue();
+			if (value.startsWith("\"") && value.endsWith("\"")) {
+				// escape existing double quotes
+				extraProperties.put("containerArg" + i++, entry.getKey() + "=\\" + value.substring(0, value.length()-1) + "\\\"");
+			} else {
+				// escape with extra double quotes
+				extraProperties.put("containerArg" + i++, entry.getKey() + "=\\\"" + value + "\\\"");
+			}
 		}
 		getApp(null, null, CloudAppType.STREAM).createCluster(ConverterUtils.toApplicationId(yarnApplicationId), clusterId, "module-template",
 				"default", 1, null, null, null, extraProperties);

--- a/spring-cloud-dataflow-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/YarnStreamModuleDeployerIT.java
+++ b/spring-cloud-dataflow-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/YarnStreamModuleDeployerIT.java
@@ -104,6 +104,7 @@ public class YarnStreamModuleDeployerIT extends AbstractCliBootYarnClusterTests 
 				.setGroup("ticktock")
 				.setName("log")
 				.setParameter("spring.cloud.stream.bindings.input", "ticktock.0")
+				.setParameter("expression", "new String(payload + ' hello')")
 				.build();
 		ArtifactCoordinates timeCoordinates = new ArtifactCoordinates.Builder()
 				.setGroupId(GROUP_ID)


### PR DESCRIPTION
- Trying to escape parameters which are passed to
  command line arguments. Also trying to check if
  parameters was already passed with quoting where we
  then just need to add escaping.
- Adding escaped quote on top of quote will fail
  because container command is passed into a separate
  shell script which executes command via exec.
- Fixes #26
