### PR TITLE
Disable basic auth on default

### DIFF
--- a/spring-cloud-dataflow-admin-yarn/src/main/resources/admin.yml
+++ b/spring-cloud-dataflow-admin-yarn/src/main/resources/admin.yml
@@ -4,6 +4,9 @@ logging:
     org.springframework.statemachine: DEBUG
 server:
   port: 9393
+security:
+  basic:
+    enabled: false
 management:
   contextPath: /management
 spring:


### PR DESCRIPTION
- Set `security.basic.enabled` to `false` on default. This
  was previously fixed in UI so that it doesn't anymore
  throw error if key not in place but side effect was that
  default behaviour(which is enabled) was activated.
- Follow logic from local admin and disable it in config, can
  be overridded in `servers.yml`.
- Fixes #28
