### PR TITLE
Shutdown appmaster when not needed

### DIFF
--- a/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/DataFlowAppmaster.java
+++ b/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/DataFlowAppmaster.java
@@ -59,7 +59,7 @@ public class DataFlowAppmaster extends ManagedContainerClusterAppmaster {
 					// this state is valid at start but we know it's not gonna
 					// get called until we have had at least one container running
 					log.info("No running containers and no container clusters, initiate app shutdown");
-					stop();
+					notifyCompleted();
 				}
 			}
 		});


### PR DESCRIPTION
- Tweak DataFlowAppmaster so that it closes itself
  and does graceful shutdown of yarn app when no containers
  are running and there is no container clusters, thus
  meaning all streams has been undeployed.
- Fixes #3
