### PR TITLE
Add better ip discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,24 @@
 				<version>2.3.0.RC2</version>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-core</artifactId>
+				<version>1.6.4</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-api-mockito</artifactId>
+				<version>1.6.4</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.powermock</groupId>
+				<artifactId>powermock-module-junit4</artifactId>
+				<version>1.6.4</version>
+				<scope>test</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 	<repositories>

--- a/spring-cloud-dataflow-admin-yarn-dist/src/main/resources/config/servers.yml
+++ b/spring-cloud-dataflow-admin-yarn-dist/src/main/resources/config/servers.yml
@@ -10,6 +10,12 @@ spring:
     port: 6379
     host: localhost
 #dataflow:
+#  hostdiscovery:
+#    pointToPoint: false
+#    loopback: false
+#    preferInterface: ['eth', 'en']
+#    matchIpv4: 192.168.0.0/24
+#    matchInterface: eth\\d*
 #  yarn:
 #    app:
 #      streamappmaster:

--- a/spring-cloud-dataflow-yarn-streamappmaster/pom.xml
+++ b/spring-cloud-dataflow-yarn-streamappmaster/pom.xml
@@ -46,6 +46,31 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-api-mockito</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.powermock</groupId>
+			<artifactId>powermock-module-junit4</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/DataflowHostInfoDiscoveryProperties.java
+++ b/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/DataflowHostInfoDiscoveryProperties.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.yarn.streamappmaster;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Shared boot configuration properties for "dataflow.hostdiscovery".
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@ConfigurationProperties(value = "dataflow.hostdiscovery")
+public class DataflowHostInfoDiscoveryProperties {
+
+	private String matchIpv4;
+	private String matchInterface;
+	private List<String> preferInterface;
+	private boolean pointToPoint = false;
+	private boolean loopback = false;
+
+	public String getMatchIpv4() {
+		return matchIpv4;
+	}
+
+	public void setMatchIpv4(String matchIpv4) {
+		this.matchIpv4 = matchIpv4;
+	}
+
+	public String getMatchInterface() {
+		return matchInterface;
+	}
+
+	public void setMatchInterface(String matchInterface) {
+		this.matchInterface = matchInterface;
+	}
+
+	public List<String> getPreferInterface() {
+		return preferInterface;
+	}
+
+	public void setPreferInterface(List<String> preferInterface) {
+		this.preferInterface = preferInterface;
+	}
+
+	public boolean isPointToPoint() {
+		return pointToPoint;
+	}
+
+	public void setPointToPoint(boolean pointToPoint) {
+		this.pointToPoint = pointToPoint;
+	}
+
+	public boolean isLoopback() {
+		return loopback;
+	}
+
+	public void setLoopback(boolean loopback) {
+		this.loopback = loopback;
+	}
+
+}

--- a/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/DefaultHostInfoDiscovery.java
+++ b/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/DefaultHostInfoDiscovery.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.dataflow.yarn.streamappmaster;
+
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.apache.commons.net.util.SubnetUtils;
+import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
+import org.springframework.util.StringUtils;
+
+/**
+ * Default implementation of {@link HostInfoDiscovery}.
+ * <p>
+ * Discovery logic for finding ip address is:
+ * <p>
+ * <ul>
+ * <li>all possible network interfaces are requested
+ * <li>for interfaces, filter out point to point if not enabled
+ * <li>for interfaces, filter out loopback if not enabled
+ * <li>for interfaces, explicit regex patter match is done if pattern is set
+ * <li>interfaces are sort by preferred name prefixes, on default "eth" and "en" are sort first
+ * <li>interfaces are sorted by their indexes assuming eth0 should be picked over eth1
+ * <li>interfaces are checked by their list of ip addresses
+ * <li>only ipv4 ip's are taken
+ * <li>cidr notation to match if from a network/mask is taken in defined
+ * <li>what is left, first found ip is taken
+ * </ul>
+ *
+ * @author Janne Valkealahti
+ *
+ */
+
+public class DefaultHostInfoDiscovery implements HostInfoDiscovery {
+
+	private String matchIpv4;
+	private String matchInterface;
+	private List<String> preferInterface = Arrays.asList("eth", "en");
+	private boolean pointToPoint = false;
+	private boolean loopback = false;
+
+	@Override
+	public HostInfo getHostInfo() {
+		List<NetworkInterface> interfaces;
+		try {
+			interfaces = getAllAvailableInterfaces();
+		} catch (SocketException e) {
+			return null;
+		}
+
+		// pre filter candidates
+		interfaces = filterInterfaces(interfaces);
+
+		// sort to prepare getting first match
+		interfaces = sortInterfaces(interfaces);
+
+		for (NetworkInterface nic : interfaces) {
+			List<InetAddress> addresses = new ArrayList<InetAddress>();
+			for (InterfaceAddress interfaceAddress : nic.getInterfaceAddresses()) {
+				addresses.add(interfaceAddress.getAddress());
+			}
+			addresses = filterAddresses(addresses);
+			if (!addresses.isEmpty()) {
+				InetAddress address = addresses.get(0);
+				return new HostInfo(address.getHostAddress(), address.getHostName());
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Sets the match ipv4. Used to match ip address from
+	 * a network using a cidr notation. For example, "192.168.0.1/24"
+	 * matches range "192.168.0.1-192.168.0.254", "192.168.0.1/16"
+	 * matches ranre "192.168.0.1-192.168.255.254" and
+	 * "10.0.0.1/8" matches range "10.0.0.1-10.255.255.254"
+	 *
+	 * @param matchIpv4 the new match ipv4
+	 */
+	public void setMatchIpv4(String matchIpv4) {
+		this.matchIpv4 = matchIpv4;
+	}
+
+	/**
+	 * Use interface as a candidate if its name is matching with a
+	 * given pattern. Default value is is empty.
+	 *
+	 * @param matchInterface the new match interface regex patter
+	 * @see NetworkInterface#getName()
+	 */
+	public void setMatchInterface(String matchInterface) {
+		this.matchInterface = matchInterface;
+	}
+
+	/**
+	 * Sets the preferred interfaces. Sort interfaces in such
+	 * order that interface names prefixed with values found from
+	 * a list is considered first candidates. Defaults to "eth" and
+	 * "en" which usually are the ones found from unix systems.
+	 *
+	 * @param preferInterface the new preferred interface list
+	 */
+	public void setPreferInterface(List<String> preferInterface) {
+		this.preferInterface = preferInterface;
+	}
+
+	/**
+	 * Sets if interfaces marked as point to point should be handled.
+	 * Point to point nic is usually a vpn tunnel which may not be no
+	 * use to talk to a host unless communication goes through vpn.
+	 * Default value is <code>FALSE</code>.
+	 *
+	 * @param pointToPoint the new point to point flag
+	 * @see NetworkInterface#isPointToPoint()
+	 */
+	public void setPointToPoint(boolean pointToPoint) {
+		this.pointToPoint = pointToPoint;
+	}
+
+	/**
+	 * Sets if loopback should be discovered.
+	 * Default value is <code>FALSE</code>.
+	 *
+	 * @param loopback the new loopback flag
+	 */
+	public void setLoopback(boolean loopback) {
+		this.loopback = loopback;
+	}
+
+	protected List<NetworkInterface> getAllAvailableInterfaces() throws SocketException {
+		List<NetworkInterface> interfaces = new ArrayList<NetworkInterface>(5);
+		for (Enumeration<NetworkInterface> e = NetworkInterface.getNetworkInterfaces(); e.hasMoreElements();) {
+			interfaces.add(e.nextElement());
+		}
+		return interfaces;
+	}
+
+	private List<InetAddress> filterAddresses(List<InetAddress> addresses) {
+		List<InetAddress> filtered = new ArrayList<InetAddress>();
+		for (InetAddress address : addresses) {
+			// take only ipv4 addresses whose byte array length is always 4
+			boolean match = address.getAddress() != null && address.getAddress().length == 4;
+
+			// check loopback
+			if (!loopback && address.isLoopbackAddress()) {
+				match = false;
+			}
+
+			// match cidr if defined
+			if (match && StringUtils.hasText(matchIpv4)) {
+				match = matchIpv4(matchIpv4, address.getHostAddress());
+			}
+
+			if (match) {
+				filtered.add(address);
+			}
+		}
+		return filtered;
+	}
+
+	private boolean matchIpv4(String addressMatch, String address) {
+		// TODO: should we fork utils from jakarta commons?
+		SubnetUtils subnetUtils = new SubnetUtils(addressMatch);
+		SubnetInfo info = subnetUtils.getInfo();
+		return info.isInRange(address);
+	}
+
+	private List<NetworkInterface> filterInterfaces(List<NetworkInterface> interfaces) {
+		List<NetworkInterface> filtered = new ArrayList<NetworkInterface>();
+		for (NetworkInterface nic : interfaces) {
+			boolean match = false;
+
+			try {
+				match = pointToPoint && nic.isPointToPoint();
+			} catch (SocketException e) {
+			}
+
+			try {
+				match = !match && loopback && nic.isLoopback();
+			} catch (SocketException e) {
+			}
+
+			// last, if we didn't match anything, let all pass
+			// if matchInterface is not set, otherwise do pattern
+			// matching
+			if (!match && !StringUtils.hasText(matchInterface)) {
+				match = true;
+			} else if (StringUtils.hasText(matchInterface)) {
+				match = nic.getName().matches(matchInterface);
+			}
+
+			if (match) {
+				filtered.add(nic);
+			}
+		}
+		return filtered;
+	}
+
+	private List<NetworkInterface> sortInterfaces(List<NetworkInterface> interfaces) {
+		Collections.sort(interfaces, new NicPreferNameComparator());
+		Collections.sort(interfaces, new NicIndexComparator());
+		return interfaces;
+	}
+
+	/**
+	 * Comparator to sort with nic index.
+	 */
+	private class NicIndexComparator implements Comparator<NetworkInterface> {
+
+		@Override
+		public int compare(NetworkInterface o1, NetworkInterface o2) {
+			return Integer.compare(o1.getIndex(), o2.getIndex());
+		}
+	}
+
+	/**
+	 * Comparator for nic names preferring a list of give prefixes order
+	 * to sort those before any other.
+	 */
+	private class NicPreferNameComparator implements Comparator<NetworkInterface> {
+
+		@Override
+		public int compare(NetworkInterface o1, NetworkInterface o2) {
+			String o1name = o1.getName();
+			String o2name = o2.getName();
+			if (startWithAny(preferInterface, o1name) && startWithAny(preferInterface, o2name)) {
+				return 0;
+			} else if (startWithAny(preferInterface, o1name) && !startWithAny(preferInterface, o2name)) {
+				return -1;
+			} else if (!startWithAny(preferInterface, o1name) && startWithAny(preferInterface, o2name)) {
+				return 1;
+			} else {
+				return o1name.compareTo(o2name);
+			}
+		}
+
+		private boolean startWithAny(List<String> prefixes, String name) {
+			for (String prefix : prefixes) {
+				if (name.startsWith(prefix)) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "DefaultHostInfoDiscovery [matchIpv4=" + matchIpv4 + ", matchInterface=" + matchInterface + ", preferInterface="
+				+ preferInterface + ", pointToPoint=" + pointToPoint + ", loopback=" + loopback + "]";
+	}
+
+}

--- a/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/HostInfoDiscovery.java
+++ b/spring-cloud-dataflow-yarn-streamappmaster/src/main/java/org/springframework/cloud/dataflow/yarn/streamappmaster/HostInfoDiscovery.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.yarn.streamappmaster;
+
+/**
+ * Interface used to discover a {@link HostInfo} from a system.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface HostInfoDiscovery {
+
+	/**
+	 * Gets the host info.
+	 *
+	 * @return the host info
+	 */
+	HostInfo getHostInfo();
+
+	public static final class HostInfo {
+		private final String address;
+		private final String hostname;
+
+		public HostInfo(String address, String hostname) {
+			super();
+			this.address = address;
+			this.hostname = hostname;
+		}
+
+		/**
+		 * Gets the ip address as represented in string.
+		 *
+		 * @return the ip address
+		 */
+		public String getAddress() {
+			return address;
+		}
+
+		/**
+		 * Gets the hostname.
+		 *
+		 * @return the hostname
+		 */
+		public String getHostname() {
+			return hostname;
+		}
+	}
+
+}

--- a/spring-cloud-dataflow-yarn-streamappmaster/src/test/java/org/springframework/cloud/dataflow/yarn/streamappmaster/DefaultHostInfoDiscoveryTests.java
+++ b/spring-cloud-dataflow-yarn-streamappmaster/src/test/java/org/springframework/cloud/dataflow/yarn/streamappmaster/DefaultHostInfoDiscoveryTests.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.yarn.streamappmaster;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.cloud.dataflow.yarn.streamappmaster.DefaultHostInfoDiscoveryTests.MockDefaultHostInfoDiscovery;
+import org.springframework.cloud.dataflow.yarn.streamappmaster.HostInfoDiscovery.HostInfo;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({NetworkInterface.class, InterfaceAddress.class, MockDefaultHostInfoDiscovery.class})
+public class DefaultHostInfoDiscoveryTests {
+
+	private static final byte NET_PREFIX = (byte) 24;
+	private static final byte[] IPV4_ADDRESS1 = new byte[] { (byte) 192, (byte) 168, 1, 1 };
+	private static final byte[] IPV4_ADDRESS2 = new byte[] { 10, 10, 10, 10 };
+	private static final byte[] IPV4_ADDRESS3 = new byte[] { (byte) 192, (byte) 168, (byte) 128, 1 };
+	private static final byte[] IPV6_ADDRESS1 = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+	private static final byte[] IPV4_LOCALHOST = new byte[] { 127, 0, 0, 1 };
+
+	@Test
+	public void testOnlyLoopbackItDisabled() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0));
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, nullValue());
+	}
+
+	@Test
+	public void testOnlyLoopbackItEnabled() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0));
+		discovery.setLoopback(true);
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, notNullValue());
+		assertThat(hostInfo.getAddress(), is("127.0.0.1"));
+		assertThat(hostInfo.getHostname(), is("localhost"));
+	}
+
+	@Test
+	public void testSingleEthSiteAddress() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		NetworkInterface nic1 = mock(NetworkInterface.class);
+		InterfaceAddress addresses1[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS1),
+				mockInterfaceAddress(IPV6_ADDRESS1)
+		};
+		when(nic1.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses1));
+		when(nic1.isPointToPoint()).thenReturn(false);
+		when(nic1.getName()).thenReturn("eth0");
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0, nic1));
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, notNullValue());
+		assertThat(hostInfo.getAddress(), is("192.168.1.1"));
+		assertThat(hostInfo.getHostname(), is("fakeHostName"));
+	}
+
+	@Test
+	public void testTwoNicsPreferEth() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		NetworkInterface nic1 = mock(NetworkInterface.class);
+		InterfaceAddress addresses1[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS1),
+				mockInterfaceAddress(IPV6_ADDRESS1)
+		};
+		when(nic1.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses1));
+		when(nic1.isPointToPoint()).thenReturn(false);
+		when(nic1.getName()).thenReturn("eth0");
+
+		NetworkInterface nic2 = mock(NetworkInterface.class);
+		InterfaceAddress addresses2[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS2)
+		};
+		when(nic2.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses2));
+		when(nic2.isPointToPoint()).thenReturn(false);
+		when(nic2.getName()).thenReturn("foo0");
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0, nic1, nic2));
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, notNullValue());
+		assertThat(hostInfo.getAddress(), is("192.168.1.1"));
+		assertThat(hostInfo.getHostname(), is("fakeHostName"));
+	}
+
+	@Test
+	public void testTwoNicsPreferEn() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		NetworkInterface nic1 = mock(NetworkInterface.class);
+		InterfaceAddress addresses1[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS1),
+				mockInterfaceAddress(IPV6_ADDRESS1)
+		};
+		when(nic1.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses1));
+		when(nic1.isPointToPoint()).thenReturn(false);
+		when(nic1.getName()).thenReturn("en0");
+
+		NetworkInterface nic2 = mock(NetworkInterface.class);
+		InterfaceAddress addresses2[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS2)
+		};
+		when(nic2.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses2));
+		when(nic2.isPointToPoint()).thenReturn(false);
+		when(nic2.getName()).thenReturn("foo0");
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0, nic1, nic2));
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, notNullValue());
+		assertThat(hostInfo.getAddress(), is("192.168.1.1"));
+		assertThat(hostInfo.getHostname(), is("fakeHostName"));
+	}
+
+	@Test
+	public void testMatchInterface() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		NetworkInterface nic1 = mock(NetworkInterface.class);
+		InterfaceAddress addresses1[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS1)
+		};
+		when(nic1.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses1));
+		when(nic1.isPointToPoint()).thenReturn(false);
+		when(nic1.getName()).thenReturn("en0");
+
+		NetworkInterface nic2 = mock(NetworkInterface.class);
+		InterfaceAddress addresses2[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS2)
+		};
+		when(nic2.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses2));
+		when(nic2.isPointToPoint()).thenReturn(false);
+		when(nic2.getName()).thenReturn("foo0");
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0, nic1, nic2));
+		discovery.setMatchInterface("foo\\d*");
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, notNullValue());
+		assertThat(hostInfo.getAddress(), is("10.10.10.10"));
+		assertThat(hostInfo.getHostname(), is("fakeHostName"));
+	}
+
+	@Test
+	public void testMatchCidr1() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		NetworkInterface nic1 = mock(NetworkInterface.class);
+		InterfaceAddress addresses1[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS1)
+		};
+		when(nic1.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses1));
+		when(nic1.isPointToPoint()).thenReturn(false);
+		when(nic1.getName()).thenReturn("eth0");
+
+		NetworkInterface nic2 = mock(NetworkInterface.class);
+		InterfaceAddress addresses2[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS2)
+		};
+		when(nic2.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses2));
+		when(nic2.isPointToPoint()).thenReturn(false);
+		when(nic2.getName()).thenReturn("eth1");
+
+		NetworkInterface nic3 = mock(NetworkInterface.class);
+		InterfaceAddress addresses3[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS3)
+		};
+		when(nic3.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses3));
+		when(nic3.isPointToPoint()).thenReturn(false);
+		when(nic3.getName()).thenReturn("eth2");
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0, nic1, nic2, nic3));
+		discovery.setMatchIpv4("192.168.1.1/24");
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, notNullValue());
+		assertThat(hostInfo.getAddress(), is("192.168.1.1"));
+		assertThat(hostInfo.getHostname(), is("fakeHostName"));
+	}
+
+	@Test
+	public void testMatchCidr2() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		NetworkInterface nic1 = mock(NetworkInterface.class);
+		InterfaceAddress addresses1[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS1)
+		};
+		when(nic1.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses1));
+		when(nic1.isPointToPoint()).thenReturn(false);
+		when(nic1.getName()).thenReturn("eth0");
+
+		NetworkInterface nic2 = mock(NetworkInterface.class);
+		InterfaceAddress addresses2[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS2)
+		};
+		when(nic2.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses2));
+		when(nic2.isPointToPoint()).thenReturn(false);
+		when(nic2.getName()).thenReturn("eth1");
+
+		NetworkInterface nic3 = mock(NetworkInterface.class);
+		InterfaceAddress addresses3[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS3)
+		};
+		when(nic3.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses3));
+		when(nic3.isPointToPoint()).thenReturn(false);
+		when(nic3.getName()).thenReturn("eth2");
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0, nic1, nic2, nic3));
+		discovery.setMatchIpv4("192.168.128.1/22");
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, notNullValue());
+		assertThat(hostInfo.getAddress(), is("192.168.128.1"));
+		assertThat(hostInfo.getHostname(), is("fakeHostName"));
+	}
+
+	@Test
+	public void testPreferNicIndex() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		NetworkInterface nic1 = mock(NetworkInterface.class);
+		InterfaceAddress addresses1[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS1)
+		};
+		when(nic1.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses1));
+		when(nic1.isPointToPoint()).thenReturn(false);
+		when(nic1.getName()).thenReturn("eth1");
+		when(nic1.getIndex()).thenReturn(1);
+
+		NetworkInterface nic2 = mock(NetworkInterface.class);
+		InterfaceAddress addresses2[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS2)
+		};
+		when(nic2.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses2));
+		when(nic2.isPointToPoint()).thenReturn(false);
+		when(nic2.getName()).thenReturn("eth0");
+		when(nic2.getIndex()).thenReturn(0);
+
+		NetworkInterface nic3 = mock(NetworkInterface.class);
+		InterfaceAddress addresses3[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS3)
+		};
+		when(nic3.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses3));
+		when(nic3.isPointToPoint()).thenReturn(false);
+		when(nic3.getName()).thenReturn("eth2");
+		when(nic3.getIndex()).thenReturn(2);
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0, nic1, nic2, nic3));
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, notNullValue());
+		assertThat(hostInfo.getAddress(), is("10.10.10.10"));
+		assertThat(hostInfo.getHostname(), is("fakeHostName"));
+	}
+
+	@Test
+	public void testComplexDiscoveryOptions() throws Exception {
+		NetworkInterface nic0 = mock(NetworkInterface.class);
+		InterfaceAddress addresses0[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_LOCALHOST)
+		};
+		when(nic0.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses0));
+		when(nic0.isLoopback()).thenReturn(true);
+		when(nic0.isPointToPoint()).thenReturn(false);
+		when(nic0.getName()).thenReturn("lo");
+
+		NetworkInterface nic1 = mock(NetworkInterface.class);
+		InterfaceAddress addresses1[] = new InterfaceAddress[]{
+				mockInterfaceAddress(IPV4_ADDRESS1),
+				mockInterfaceAddress(IPV6_ADDRESS1)
+		};
+		when(nic1.getInterfaceAddresses()).thenReturn(Arrays.asList(addresses1));
+		when(nic1.isPointToPoint()).thenReturn(false);
+		when(nic1.getName()).thenReturn("eth0");
+
+		MockDefaultHostInfoDiscovery discovery = new MockDefaultHostInfoDiscovery(Arrays.asList(nic0, nic1));
+		discovery.setMatchInterface("eth\\d*");
+		discovery.setMatchIpv4("192.168.1.1/24");
+		HostInfo hostInfo = discovery.getHostInfo();
+		assertThat(hostInfo, notNullValue());
+		assertThat(hostInfo.getAddress(), is("192.168.1.1"));
+		assertThat(hostInfo.getHostname(), is("fakeHostName"));
+	}
+
+	private InterfaceAddress mockInterfaceAddress(final byte[] netAddress) {
+		final InterfaceAddress intAddress = mockInterfaceAddress(netAddress, NET_PREFIX);
+		if (netAddress.equals(IPV4_LOCALHOST)) {
+			InetAddress address = mock(InetAddress.class);
+			when(address.getAddress()).thenReturn(IPV4_LOCALHOST);
+			when(address.isLoopbackAddress()).thenReturn(true);
+			when(address.isAnyLocalAddress()).thenReturn(false);
+			when(address.getHostAddress()).thenReturn("127.0.0.1");
+			when(address.getHostName()).thenReturn("localhost");
+			when(intAddress.getAddress()).thenReturn(address);
+		} else if (netAddress.equals(IPV4_ADDRESS1)) {
+			InetAddress address = mock(InetAddress.class);
+			when(address.getAddress()).thenReturn(IPV4_ADDRESS1);
+			when(address.isLoopbackAddress()).thenReturn(false);
+			when(address.isAnyLocalAddress()).thenReturn(false);
+			when(address.getHostAddress()).thenReturn("192.168.1.1");
+			when(address.getHostName()).thenReturn("fakeHostName");
+			when(intAddress.getAddress()).thenReturn(address);
+		} else if (netAddress.equals(IPV4_ADDRESS2)) {
+			InetAddress address = mock(InetAddress.class);
+			when(address.getAddress()).thenReturn(IPV4_ADDRESS2);
+			when(address.isLoopbackAddress()).thenReturn(false);
+			when(address.getHostAddress()).thenReturn("10.10.10.10");
+			when(address.getHostName()).thenReturn("fakeHostName");
+			when(intAddress.getAddress()).thenReturn(address);
+		} else if (netAddress.equals(IPV4_ADDRESS3)) {
+			InetAddress address = mock(InetAddress.class);
+			when(address.getAddress()).thenReturn(IPV4_ADDRESS3);
+			when(address.isLoopbackAddress()).thenReturn(false);
+			when(address.isAnyLocalAddress()).thenReturn(false);
+			when(address.getHostAddress()).thenReturn("192.168.128.1");
+			when(address.getHostName()).thenReturn("fakeHostName");
+			when(intAddress.getAddress()).thenReturn(address);
+		}
+		return intAddress;
+	}
+
+	private InterfaceAddress mockInterfaceAddress(final byte[] netAddress, final int netPrefix) {
+		InetAddress address = mock(InetAddress.class);
+		when(address.getAddress()).thenReturn(netAddress);
+
+		InterfaceAddress adapter = mock(InterfaceAddress.class);
+		when(adapter.getAddress()).thenReturn(address);
+		when(adapter.getNetworkPrefixLength()).thenReturn((short) netPrefix);
+		return adapter;
+	}
+
+	public static class MockDefaultHostInfoDiscovery extends DefaultHostInfoDiscovery {
+
+		List<NetworkInterface> interfaces;
+
+		public MockDefaultHostInfoDiscovery(List<NetworkInterface> interfaces) {
+			this.interfaces = interfaces;
+		}
+
+		@Override
+		protected List<NetworkInterface> getAllAvailableInterfaces() throws SocketException {
+			return interfaces;
+		}
+
+	}
+}


### PR DESCRIPTION
- NOTE: tweak in appmaster and code should eventually
  land in SHDP.
- New HostInfoDiscovery and its default implementation
  DefaultHostInfoDiscovery which provide better discovery
  methods for finding local master/base ip.
- It's added to StreamAppmasterApplication as bean and
  can be configured via DataflowHostInfoDiscoveryProperties.
- Tests are done via powermock which is, afaik, only lib
  which can mock jdk system classes like NetworkInterface, etc.
- Fixes #35
