### PR TITLE
Fix deploy failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<spring-cloud-stream.version>1.0.0.M3</spring-cloud-stream.version>
 		<spring-cloud-dataflow.version>1.0.0.M2</spring-cloud-dataflow.version>
 		<spring-hadoop.version>2.3.0.RC2</spring-hadoop.version>
-		<spring-statemachine.version>1.0.2.RC1</spring-statemachine.version>
+		<spring-statemachine.version>1.0.2.RELEASE</spring-statemachine.version>
 	</properties>
 
 	<modules>

--- a/spring-cloud-dataflow-admin-yarn/src/test/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnCloudAppTaskStateMachineTests.java
+++ b/spring-cloud-dataflow-admin-yarn/src/test/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnCloudAppTaskStateMachineTests.java
@@ -146,6 +146,13 @@ public class YarnCloudAppTaskStateMachineTests {
 		context.close();
 	}
 
+	@Test
+	public void smokeTestDeployTwice() throws Exception {
+		for (int i = 0; i < 100; i++) {
+			testDeployTwice();
+		}
+	}
+
 	@Configuration
 	static class Config {
 


### PR DESCRIPTION
- Threading issued turned out to be in a state machine
  core which time to time lost simultaneus events processed
  in a separate thread. Added a smoke test for this.
- Update to state machine 1.0.2.RELEASE
- Fixes #39
