### PR TITLE
Separate streams into different yarn apps

### DIFF
--- a/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/DefaultYarnCloudAppService.java
+++ b/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/DefaultYarnCloudAppService.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -46,17 +46,19 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService, Initiali
 	private final Map<String, YarnCloudAppServiceApplication> appCache = new HashMap<String, YarnCloudAppServiceApplication>();
 
 	/**
+	 * Instantiates a new default yarn cloud app service.
 	 *
-	 * @param dataflowVersion
+	 * @param dataflowVersion the dataflow version
 	 */
 	public DefaultYarnCloudAppService(String dataflowVersion) {
 		this(dataflowVersion, null);
 	}
 
 	/**
+	 * Instantiates a new default yarn cloud app service.
 	 *
-	 * @param dataflowVersion
-	 * @param initializers
+	 * @param dataflowVersion the dataflow version
+	 * @param initializers the initializers
 	 */
 	public DefaultYarnCloudAppService(String dataflowVersion, ApplicationContextInitializer<?>[] initializers) {
 		this.dataflowVersion = dataflowVersion;
@@ -139,7 +141,7 @@ public class DefaultYarnCloudAppService implements YarnCloudAppService, Initiali
 	public Map<String, String> getClustersStates() {
 		HashMap<String, String> states = new HashMap<String, String>();
 		for (CloudAppInstanceInfo instanceInfo : getInstances(CloudAppType.STREAM)) {
-			if (instanceInfo.getName().equals("scdstream:app") && instanceInfo.getState().equals("RUNNING")) {
+			if (instanceInfo.getName().startsWith("scdstream:app") && instanceInfo.getState().equals("RUNNING")) {
 				for (String cluster : getClusters(instanceInfo.getApplicationId())) {
 					states.putAll(getInstanceClustersStates(instanceInfo.getApplicationId(), cluster));
 				}

--- a/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnStreamModuleDeployer.java
+++ b/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnStreamModuleDeployer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ public class YarnStreamModuleDeployer implements ModuleDeployer {
 		ModuleDefinition definition = request.getDefinition();
 		ModuleDeploymentId id = ModuleDeploymentId.fromModuleDefinition(definition);
 		String clusterId = moduleDeploymentIdToClusterId(id);
+		String group = id.getGroup();
 		String module = coordinates.toString();
 		Map<String, String> definitionParameters = definition.getParameters();
 		Map<String, String> deploymentProperties = request.getDeploymentProperties();
@@ -83,6 +84,7 @@ public class YarnStreamModuleDeployer implements ModuleDeployer {
 		Message<Events> message = MessageBuilder.withPayload(Events.DEPLOY)
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_APP_VERSION, "app")
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_CLUSTER_ID, clusterId)
+				.setHeader(YarnCloudAppStreamStateMachine.HEADER_GROUP_ID, group)
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_COUNT, count)
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_MODULE, module)
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_DEFINITION_PARAMETERS, definitionParameters)
@@ -95,8 +97,11 @@ public class YarnStreamModuleDeployer implements ModuleDeployer {
 	@Override
 	public void undeploy(ModuleDeploymentId id) {
 		String clusterId = moduleDeploymentIdToClusterId(id);
+		String group = id.getGroup();
 		Message<Events> message = MessageBuilder.withPayload(Events.UNDEPLOY)
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_CLUSTER_ID, clusterId)
+				.setHeader(YarnCloudAppStreamStateMachine.HEADER_APP_VERSION, "app")
+				.setHeader(YarnCloudAppStreamStateMachine.HEADER_GROUP_ID, group)
 				.build();
 		stateMachine.sendEvent(message);
 	}

--- a/spring-cloud-dataflow-admin-yarn/src/test/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnCloudAppStreamStateMachineTests.java
+++ b/spring-cloud-dataflow-admin-yarn/src/test/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnCloudAppStreamStateMachineTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,6 +120,7 @@ public class YarnCloudAppStreamStateMachineTests {
 		Message<Events> message = MessageBuilder.withPayload(Events.DEPLOY)
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_APP_VERSION, "app")
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_CLUSTER_ID, "fakeClusterId")
+				.setHeader(YarnCloudAppStreamStateMachine.HEADER_GROUP_ID, "fakeGroup")
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_COUNT, 1)
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_MODULE, "fakeModule")
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_DEFINITION_PARAMETERS, new HashMap<Object, Object>())
@@ -186,6 +187,7 @@ public class YarnCloudAppStreamStateMachineTests {
 		Message<Events> message = MessageBuilder.withPayload(Events.DEPLOY)
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_APP_VERSION, "app")
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_CLUSTER_ID, "fakeClusterId")
+				.setHeader(YarnCloudAppStreamStateMachine.HEADER_GROUP_ID, "fakeGroup")
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_COUNT, 1)
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_MODULE, "fakeModule")
 				.setHeader(YarnCloudAppStreamStateMachine.HEADER_DEFINITION_PARAMETERS, new HashMap<Object, Object>())
@@ -338,7 +340,10 @@ public class YarnCloudAppStreamStateMachineTests {
 
 		@Override
 		public String submitApplication(String appVersion, CloudAppType cloudAppType, List<String> contextRunArgs) {
-			return null;
+			instance = "scdstream:" + appVersion + ":fakeGroup";
+			submitApplicationCount.add(new Wrapper(appVersion));
+			submitApplicationLatch.countDown();
+			return "fakeApplicationId";
 		}
 
 		@Override


### PR DESCRIPTION
- Every stream is now going to be a dedicated
  yarn app giving a change to do further development
  for stream module specific features such as
  node labeling.
- Yarn app name is now `scdstream:app:foo1` where
  last part is a stream name. Running modules are then
  identified by this app name. Actual modules would then
  be find from this app.
- We may put back some features in a future to allow
  streams to share a same app to re-use appmaster resource.
- One multi-stream test is commented out due to trouble
  not having enough resources in a minicluster to launch
  multiple apps, keeping it stashed there if we find ways
  to use that test.
- Fixes #2
