### PR TITLE
Enable application queue and node labeling

### DIFF
--- a/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnCloudAppStreamStateMachine.java
+++ b/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnCloudAppStreamStateMachine.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.dataflow.module.deployer.yarn;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +53,7 @@ public class YarnCloudAppStreamStateMachine {
 	static final String HEADER_COUNT = "count";
 	static final String HEADER_MODULE = "module";
 	static final String HEADER_DEFINITION_PARAMETERS = "definitionParameters";
+	static final String HEADER_CONTEXT_RUN_ARGS = "contextRunArgs";
 	static final String HEADER_ERROR = "error";
 
 	private final YarnCloudAppService yarnCloudAppService;
@@ -295,8 +295,10 @@ public class YarnCloudAppStreamStateMachine {
 			String appVersion = (String) context.getMessageHeader(HEADER_APP_VERSION);
 			String groupId = (String) context.getMessageHeader(HEADER_GROUP_ID);
 			String appName = "scdstream:" + appVersion + ":" + groupId;
-			List<String> contextRunArgs = new ArrayList<String>();
-			contextRunArgs.add("--spring.yarn.appName=" + appName);
+
+			// we control type so casting is safe
+			@SuppressWarnings("unchecked")
+			List<String> contextRunArgs = (List<String>) context.getMessageHeader(HEADER_CONTEXT_RUN_ARGS);
 			String applicationId = yarnCloudAppService.submitApplication(appVersion, CloudAppType.STREAM, contextRunArgs);
 			context.getExtendedState().getVariables().put(VAR_APPLICATION_ID, applicationId);
 

--- a/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnTaskModuleDeployer.java
+++ b/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/module/deployer/yarn/YarnTaskModuleDeployer.java
@@ -77,6 +77,11 @@ public class YarnTaskModuleDeployer implements ModuleDeployer {
 		logger.info("definitionParameters: " + definitionParameters);
 		logger.info("deploymentProperties: " + deploymentProperties);
 
+		// as a tmp solution, zap module.<taskmodule>. from properties
+		// because TaskController doesn't do it like Streams do
+		deploymentProperties = extractModuleDeploymentProperties(definition, deploymentProperties);
+		logger.info("extracted deploymentProperties: " + deploymentProperties);
+
 		// contextRunArgs are passed to boot app ran to control yarn apps
 		// we pass needed args to control module coordinates and params,
 		// weird format with '--' is just straight pass to container
@@ -155,6 +160,18 @@ public class YarnTaskModuleDeployer implements ModuleDeployer {
 		} else {
 			throw new IllegalArgumentException("Invalid appName=[" + appName + "]");
 		}
+	}
+
+	private Map<String, String> extractModuleDeploymentProperties(ModuleDefinition module,
+			Map<String, String> streamDeploymentProperties) {
+		String prefix = "module." + module.getLabel() + ".";
+		Map<String, String> properties = new HashMap<>();
+		for (Entry<String, String> entry : streamDeploymentProperties.entrySet()) {
+			if (entry.getKey().startsWith(prefix)) {
+				properties.put(entry.getKey().substring(prefix.length()), entry.getValue());
+			}
+		}
+		return properties;
 	}
 
 }

--- a/spring-cloud-dataflow-admin-yarn/src/main/resources/stream.yml
+++ b/spring-cloud-dataflow-admin-yarn/src/main/resources/stream.yml
@@ -19,6 +19,8 @@ spring:
         - "file:${dataflow.yarn.app.appmaster.path:lib}/spring-cloud-dataflow-yarn-streamappmaster-*.jar"
         - "file:${dataflow.yarn.app.container.path:lib}/spring-cloud-dataflow-yarn-streamcontainer-*.jar"
         - "file:${dataflow.yarn.app.config.path:config}/servers.yml"
+      queue: ${dataflow.yarn.app.streamappmaster.queue:default}
+      labelExpression: ${dataflow.yarn.app.streamappmaster.labelExpression:}
       launchcontext:
         arguments:
           -Dspring.config.location: servers.yml

--- a/spring-cloud-dataflow-admin-yarn/src/main/resources/task.yml
+++ b/spring-cloud-dataflow-admin-yarn/src/main/resources/task.yml
@@ -18,6 +18,8 @@ spring:
         - "file:${dataflow.yarn.app.appmaster.path:lib}/spring-cloud-dataflow-yarn-taskappmaster-*.jar"
         - "file:${dataflow.yarn.app.container.path:lib}/spring-cloud-dataflow-yarn-taskcontainer-*.jar"
         - "file:${dataflow.yarn.app.config.path:config}/servers.yml"
+      queue: ${dataflow.yarn.app.taskappmaster.queue:default}
+      labelExpression: ${dataflow.yarn.app.taskappmaster.labelExpression:}
       launchcontext:
         options:
           - ${dataflow.yarn.app.taskappmaster.javaOpts:}

--- a/spring-cloud-dataflow-yarn-streamappmaster/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-yarn-streamappmaster/src/main/resources/application.yml
@@ -31,6 +31,7 @@ spring:
               priority: ${dataflow.yarn.app.streamcontainer.priority:5}
               memory: ${dataflow.yarn.app.streamcontainer.memory:256m}
               virtualCores: ${dataflow.yarn.app.streamcontainer.virtualCores:1}
+              labelExpression: ${dataflow.yarn.app.streamcontainer.labelExpression:}
             launchcontext:
               options:
                 - ${dataflow.yarn.app.streamcontainer.javaOpts:}

--- a/spring-cloud-dataflow-yarn-taskappmaster/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-yarn-taskappmaster/src/main/resources/application.yml
@@ -24,6 +24,7 @@ spring:
           - "servers.yml"
       resource:
         priority: ${dataflow.yarn.app.taskcontainer.priority:10}
+        labelExpression: ${dataflow.yarn.app.taskcontainer.labelExpression:}
         memory: ${dataflow.yarn.app.taskcontainer.memory:256m}
         virtualCores: ${dataflow.yarn.app.taskcontainer.virtualCores:1}
       launchcontext:


### PR DESCRIPTION
- During a stream and task deployments it's now possible to define
  yarn application queue and labelExpression which are then used by
  a scheduler during a resource allocation.
- Queue and label expression is passed via deployment properties and
  defaults to 'default' and empty respectively.
- Queue is always application level setting as it is used by a client
  submitting app into a yarn.
- Label expressions works on a two level. On appmaster level, if set will
  allocate resources from yarn based on expression for both appmaster and containers.
  If expression is also set on a container level, that will override application
  level setting effectively allowing to place appmaster on different location than
  containers.
- For streams, all modules need to share same setting. This maybe lifted in a future
  so that we can place individual modules on different nodes based on labeling.
- Usage from shell goes along these lines:

```
  task create --name footask --definition "timestamp"
  task launch --name footask --properties "module.timestamp.dataflow.yarn.app.taskappmaster.queue=unfunded"
  task launch --name footask --properties "module.timestamp.dataflow.yarn.app.taskappmaster.labelExpression=green"
  task launch --name footask --properties "module.timestamp.dataflow.yarn.app.taskappmaster.labelExpression=green,module.timestamp.dataflow.yarn.app.taskcontainer.labelExpression=red"
  stream create --name foostream --definition "time|log"
  stream deploy --name foostream --properties "module.*.dataflow.yarn.app.streamappmaster.queue=unfunded"
  stream deploy --name foostream --properties "module.*.dataflow.yarn.app.streamappmaster.labelExpression=green"
  stream deploy --name foostream --properties "module.*.dataflow.yarn.app.streamappmaster.labelExpression=green,module.*.dataflow.yarn.app.streamcontainer.labelExpression=red"
```
- Fixes spring-cloud/spring-cloud-dataflow-admin-yarn#14
- Fixes spring-cloud/spring-cloud-dataflow-admin-yarn#20
- Fixes spring-cloud/spring-cloud-dataflow-admin-yarn#48
