### PR TITLE
GH-59 Autoconfigure YARN admin deployer

### DIFF
--- a/spring-cloud-dataflow-admin-yarn/pom.xml
+++ b/spring-cloud-dataflow-admin-yarn/pom.xml
@@ -64,6 +64,7 @@
 					<include>task.yml</include>
 					<include>stream.yml</include>
 					<include>banner.txt</include>
+					<include>META-INF/spring.factories</include>
 				</includes>
 			</resource>
 		</resources>

--- a/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/admin/spi/yarn/YarnAdminAutoConfiguration.java
+++ b/spring-cloud-dataflow-admin-yarn/src/main/java/org/springframework/cloud/dataflow/admin/spi/yarn/YarnAdminAutoConfiguration.java
@@ -36,7 +36,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  * @author Ilayaperumal Gopinathan
  */
 @Configuration
-public class YarnAdminConfiguration {
+public class YarnAdminAutoConfiguration {
 
 	@Value("${spring.cloud.dataflow.yarn.version}")
 	private String dataflowVersion;

--- a/spring-cloud-dataflow-admin-yarn/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-dataflow-admin-yarn/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=org.springframework.cloud.dataflow.admin.spi.yarn.YarnAutoConfiguration

--- a/spring-cloud-dataflow-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/YarnStreamModuleDeployerIT.java
+++ b/spring-cloud-dataflow-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/YarnStreamModuleDeployerIT.java
@@ -38,7 +38,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.dataflow.admin.spi.yarn.YarnAdminConfiguration;
+import org.springframework.cloud.dataflow.admin.spi.yarn.YarnAdminAutoConfiguration;
 import org.springframework.cloud.dataflow.core.ArtifactCoordinates;
 import org.springframework.cloud.dataflow.core.ModuleDefinition;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
@@ -423,7 +423,7 @@ public class YarnStreamModuleDeployerIT extends AbstractCliBootYarnClusterTests 
 	}
 
 	@Configuration
-	public static class TestYarnConfiguration extends YarnAdminConfiguration {
+	public static class TestYarnConfiguration extends YarnAdminAutoConfiguration {
 
 		@Autowired
 		private org.apache.hadoop.conf.Configuration configuration;

--- a/spring-cloud-dataflow-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/YarnTaskModuleDeployerIT.java
+++ b/spring-cloud-dataflow-yarn-build-tests/src/test/java/org/springframework/cloud/dataflow/yarn/buildtests/YarnTaskModuleDeployerIT.java
@@ -16,7 +16,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.dataflow.admin.spi.yarn.YarnAdminConfiguration;
+import org.springframework.cloud.dataflow.admin.spi.yarn.YarnAdminAutoConfiguration;
 import org.springframework.cloud.dataflow.core.ArtifactCoordinates;
 import org.springframework.cloud.dataflow.core.ModuleDefinition;
 import org.springframework.cloud.dataflow.core.ModuleDeploymentId;
@@ -136,7 +136,7 @@ public class YarnTaskModuleDeployerIT extends AbstractCliBootYarnClusterTests {
 	}
 
 	@Configuration
-	public static class TestYarnConfiguration extends YarnAdminConfiguration {
+	public static class TestYarnConfiguration extends YarnAdminAutoConfiguration {
 
 		@Autowired
 		private org.apache.hadoop.conf.Configuration configuration;


### PR DESCRIPTION
This is similar to changes in other admins.  I wasn't able to get tests passing even before making my changes, so not sure on if there are any other changes.  I did have to change tests to reference

```
 @SpringApplicationConfiguration(classes = org.springframework.cloud.dataflow.admin.AdminApplication.class)
```

instead of the local project configuration (otherwise AdminPropertites was not included as a bean)
