### PR TITLE
Modify kill wait time in tests

### DIFF
--- a/spring-cloud-dataflow-yarn-build-tests/src/test/resources/yarn-site.xml
+++ b/spring-cloud-dataflow-yarn-build-tests/src/test/resources/yarn-site.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+
+<!-- Put site-specific property overrides in this file. -->
+
+<configuration>
+   <property>
+        <name>yarn.nodemanager.sleep-delay-before-sigkill.ms</name>
+        <value>10000</value>
+   </property>
+
+</configuration>
+


### PR DESCRIPTION
- Adding yarn-site to test classpath so that minicluster
  will pick it up and change default 250ms to 10sec. This
  time is what nodemanager waits between term and kill
  signals. Should help for apps in container to get time
  to shutdown because we assert those stopping messages.
- Fixes #66
