### PR TITLE
Rename admin-starter dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dataflow-admin-starter</artifactId>
+				<artifactId>spring-cloud-dataflow-server-core</artifactId>
 				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>

--- a/spring-cloud-dataflow-admin-yarn/pom.xml
+++ b/spring-cloud-dataflow-admin-yarn/pom.xml
@@ -34,7 +34,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-dataflow-admin-starter</artifactId>
+			<artifactId>spring-cloud-dataflow-server-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
- Change from admin-starter to server-core as
  parent has been changed.
- Fixes #70
