### PR TITLE
Adjust spring-cloud-dataflow dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,6 @@
 				<version>${spring-cloud-dataflow.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dataflow-module-deployer-spi</artifactId>
-				<version>${spring-cloud-dataflow.version}</version>
-			</dependency>
-			<dependency>
 				<groupId>org.springframework.statemachine</groupId>
 				<artifactId>spring-statemachine-core</artifactId>
 				<version>${spring-statemachine.version}</version>


### PR DESCRIPTION
- Actually dep for spring-cloud-dataflow-module-deployer-spi came
  from parent so spring-cloud-dataflow-deployer-spi will come from
  there too. Removing old entry which was only in dep management
  in a main pom.
- Fixes #74
