### PR TITLE
Upgrade to statemachine 1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,13 +15,13 @@
 	</parent>
 
 	<properties>
-		<spring-cloud-deployer-yarn.version>1.0.0.M1</spring-cloud-deployer-yarn.version>
+		<spring-cloud-deployer-yarn.version>1.0.0.BUILD-SNAPSHOT</spring-cloud-deployer-yarn.version>
 		<spring-cloud-deployer.version>1.0.0.M1</spring-cloud-deployer.version>
 		<spring-cloud-stream.version>1.0.0.RC3</spring-cloud-stream.version>
 		<spring-cloud-stream-app.version>1.0.0.M1</spring-cloud-stream-app.version>
 		<spring-cloud-task-app.version>1.0.0.M1</spring-cloud-task-app.version>
 		<spring-cloud-dataflow.version>1.0.0.M3</spring-cloud-dataflow.version>
-		<spring-statemachine.version>1.1.0.M2</spring-statemachine.version>
+		<spring-statemachine.version>1.1.0.RELEASE</spring-statemachine.version>
 		<spring-hadoop.version>2.4.0.M1</spring-hadoop.version>
 	</properties>
 

--- a/spring-cloud-dataflow-server-yarn-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/yarn/YarnAdminAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-yarn-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/yarn/YarnAdminAutoConfiguration.java
@@ -39,6 +39,7 @@ import org.springframework.cloud.deployer.spi.yarn.TaskLauncherStateMachine;
 import org.springframework.cloud.deployer.spi.yarn.YarnAppDeployer;
 import org.springframework.cloud.deployer.spi.yarn.YarnCloudAppService;
 import org.springframework.cloud.deployer.spi.yarn.YarnTaskLauncher;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
@@ -124,8 +125,8 @@ public class YarnAdminAutoConfiguration {
 
 		@Bean
 		public AppDeployerStateMachine appDeployerStateMachine(YarnCloudAppService yarnCloudAppService,
-				TaskExecutor yarnModuleDeployerTaskExecutor, BeanFactory beanFactory) throws Exception {
-			return new AppDeployerStateMachine(yarnCloudAppService, yarnModuleDeployerTaskExecutor, beanFactory);
+				TaskExecutor yarnModuleDeployerTaskExecutor, BeanFactory beanFactory, ApplicationContext applicationContext) throws Exception {
+			return new AppDeployerStateMachine(yarnCloudAppService, yarnModuleDeployerTaskExecutor, beanFactory, applicationContext);
 		}
 
 		@Bean
@@ -141,8 +142,8 @@ public class YarnAdminAutoConfiguration {
 
 		@Bean
 		public TaskLauncherStateMachine taskLauncherStateMachine(YarnCloudAppService yarnCloudAppService,
-				TaskExecutor yarnModuleDeployerTaskExecutor, BeanFactory beanFactory) throws Exception {
-			return new TaskLauncherStateMachine(yarnCloudAppService, yarnModuleDeployerTaskExecutor, beanFactory);
+				TaskExecutor yarnModuleDeployerTaskExecutor, BeanFactory beanFactory, ApplicationContext applicationContext) throws Exception {
+			return new TaskLauncherStateMachine(yarnCloudAppService, yarnModuleDeployerTaskExecutor, beanFactory, applicationContext);
 		}
 
 		@Bean


### PR DESCRIPTION
NOTE: goes together with https://github.com/spring-cloud/spring-cloud-deployer-yarn/pull/10
- Upgrade to statemachine release version.
- Related changes needed for deployer overhaul.
- Fixes #105
- Fixes #18
