### PR TITLE
Add hdfs shell related commands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
 		<module>spring-cloud-dataflow-server-yarn-client</module>
 		<module>spring-cloud-dataflow-server-yarn-docs</module>
 		<module>spring-cloud-dataflow-server-yarn-h2</module>
+		<module>spring-cloud-dataflow-server-yarn-shell-core</module>
+		<module>spring-cloud-dataflow-server-yarn-shell</module>
 		<module>spring-cloud-starter-dataflow-server-yarn</module>
 		<module>spring-cloud-dataflow-server-yarn-dist</module>
 	</modules>
@@ -86,6 +88,11 @@
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-deployer-yarn-autoconfig</artifactId>
 				<version>${spring-cloud-deployer-yarn.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.data</groupId>
+				<artifactId>spring-data-hadoop-boot</artifactId>
+				<version>${spring-hadoop.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.data</groupId>

--- a/spring-cloud-dataflow-server-yarn-dist/pom.xml
+++ b/spring-cloud-dataflow-server-yarn-dist/pom.xml
@@ -17,8 +17,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-dataflow-shell</artifactId>
-			<version>${spring-cloud-dataflow.version}</version>
+			<artifactId>spring-cloud-dataflow-server-yarn-shell</artifactId>
+			<version>1.0.1.BUILD-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-dataflow-server-yarn-dist/src/main/assembly/assembly.xml
+++ b/spring-cloud-dataflow-server-yarn-dist/src/main/assembly/assembly.xml
@@ -30,7 +30,7 @@
 				<include>org.springframework.cloud:spring-cloud-deployer-yarn-appdeployerappmaster</include>
 				<include>org.springframework.cloud:spring-cloud-deployer-yarn-tasklauncherappmaster</include>
 				<include>org.springframework.cloud:spring-cloud-dataflow-server-yarn-client</include>
-				<include>org.springframework.cloud:spring-cloud-dataflow-shell</include>
+				<include>org.springframework.cloud:spring-cloud-dataflow-server-yarn-shell</include>
 			</includes>
 		</dependencySet>
 	</dependencySets>

--- a/spring-cloud-dataflow-server-yarn-dist/src/main/resources/bin/dataflow-shell
+++ b/spring-cloud-dataflow-server-yarn-dist/src/main/resources/bin/dataflow-shell
@@ -7,7 +7,7 @@
 ##############################################################################
 
 # Add default JVM options here. You can also use JAVA_OPTS and SPRING_CLOUD_DATAFLOW_SHELL_OPTS to pass JVM options to this script.
-DATAFLOW_SHELL_VERSION="@spring-cloud-dataflow.version@"
+DATAFLOW_VERSION="@project.version@"
 DEFAULT_JVM_OPTS=""
 APP_NAME="dataflow-shell"
 APP_BASE_NAME=`basename "$0"`
@@ -154,10 +154,26 @@ if $cygwin ; then
     esac
 fi
 
+# check if SCDF_HOME is already set; if it is not, then set APP_HOME as SCDF_HOME
+if [ x"$SCDF_HOME" = x ] ; then
+    export SCDF_HOME=$APP_HOME
+fi
+
+# Check for explicity set SCDF_CONFIG_*
+if [ x"$SCDF_CONFIG_LOCATION" = x ] ; then
+    export SCDF_CONFIG_LOCATION=$SCDF_HOME/config
+fi
+export SCDF_CONFIG_LOCATION=$SCDF_CONFIG_LOCATION/
+if [ x"$SCDF_CONFIG_NAME" = x ] ; then
+    export SCDF_CONFIG_NAME=servers,application
+fi
+
+DATAFLOW_OPTS="-Dspring.config.location=${SCDF_CONFIG_LOCATION}/servers.yml,${SCDF_CONFIG_LOCATION}/cli.yml"
+
 # Split up the JVM_OPTS And SPRING_ClOUD_DATAFLOW_SHELL_OPTS values into an array, following the shell quoting and substitution rules
 function splitJvmOpts() {
     JVM_OPTS=("$@")
 }
-eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $SPRING_CLOUD_DATAFLOW_SHELL_OPTS
+eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $SPRING_CLOUD_DATAFLOW_SHELL_OPTS $DATAFLOW_OPTS
 
-exec "$JAVACMD" "${JVM_OPTS[@]}" -jar "${APP_HOME_LIB}/spring-cloud-dataflow-shell-${DATAFLOW_SHELL_VERSION}.jar" "${args[@]}"
+exec "$JAVACMD" "${JVM_OPTS[@]}" -jar "${APP_HOME_LIB}/spring-cloud-dataflow-server-yarn-shell-${DATAFLOW_VERSION}.jar" "${args[@]}"

--- a/spring-cloud-dataflow-server-yarn-shell-core/pom.xml
+++ b/spring-cloud-dataflow-server-yarn-shell-core/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-cloud-dataflow-server-yarn-shell-core</artifactId>
+	<version>1.0.1.BUILD-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>spring-cloud-dataflow-server-yarn-shell-core</name>
+	<description>Data Flow Server Shell Core for Apache Yarn</description>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-dataflow-server-yarn-parent</artifactId>
+		<version>1.0.1.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-dataflow-shell</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-hadoop-boot</artifactId>
+		</dependency>
+	</dependencies>
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>application.yml</include>
+				</includes>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-cloud-dataflow-server-yarn-shell-core/src/main/java/org/springframework/cloud/dataflow/server/yarn/shell/core/HadoopCommands.java
+++ b/spring-cloud-dataflow-server-yarn-shell-core/src/main/java/org/springframework/cloud/dataflow/server/yarn/shell/core/HadoopCommands.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.yarn.shell.core;
+
+import java.text.SimpleDateFormat;
+import java.util.Collection;
+import java.util.Date;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.hadoop.fs.FsShell;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.shell.table.AbsoluteWidthSizeConstraints;
+import org.springframework.shell.table.BorderSpecification;
+import org.springframework.shell.table.BorderStyle;
+import org.springframework.shell.table.CellMatchers;
+import org.springframework.shell.table.Formatter;
+import org.springframework.shell.table.Table;
+import org.springframework.shell.table.TableBuilder;
+import org.springframework.shell.table.TableModel;
+import org.springframework.stereotype.Component;
+
+/**
+ * Shell hdfs related commands.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+@Component
+public class HadoopCommands implements CommandMarker {
+
+	private static final String PREFIX = "hadoop fs ";
+	private static final String FALSE = "false";
+	private static final String TRUE = "true";
+	private static final String FROM = "from";
+	private static final String TO = "to";
+	private static final String IGNORECRC = "ignoreCrc";
+	private static final String CRC = "crc";
+	private static final String DIR = "dir";
+	private static final String SKIPTRASH = "skipTrash";
+	private static final String RECURSIVE = "recursive";
+	private static final String RECURSION_HELP = "whether with recursion";
+	private static final String SOURCE_FILE_NAMES = "source file names";
+	private static final String DESTINATION_PATH_NAME = "destination path name";
+	private static final String PATH = "path";
+
+	private FsShell shell;
+
+	@Autowired
+	public void setFsShell(FsShell shell) {
+		this.shell = shell;
+	}
+
+	@CliCommand(value = PREFIX + "ls", help = "List files in the directory")
+	public Table ls(
+			@CliOption(key = { "", DIR }, mandatory = false, unspecifiedDefaultValue = ".", help = "directory to be listed") final String path,
+			@CliOption(key = { RECURSIVE }, mandatory = false, specifiedDefaultValue = TRUE, unspecifiedDefaultValue = FALSE, help = RECURSION_HELP) final boolean recursive) {
+		Collection<FileStatus> files = recursive ? shell.lsr(path) : shell.ls(path);
+		return applySimpleListStyle(new TableBuilder(new FileStatusTableModel(files.toArray(new FileStatus[0])))).build();
+	}
+
+	@CliCommand(value = PREFIX + "rm", help = "Remove files in the HDFS")
+	public void rm(
+			@CliOption(key = { "", PATH }, mandatory = false, unspecifiedDefaultValue = ".", help = "path to be deleted") final String path,
+			@CliOption(key = { SKIPTRASH }, mandatory = false, specifiedDefaultValue = TRUE, unspecifiedDefaultValue = FALSE, help = "whether to skip trash") final boolean skipTrash,
+			@CliOption(key = { RECURSIVE }, mandatory = false, specifiedDefaultValue = TRUE, unspecifiedDefaultValue = FALSE, help = "whether to recurse") final boolean recursive) {
+		shell.rm(recursive, skipTrash, path);
+	}
+
+	@CliCommand(value = PREFIX + "cat", help = "Copy source paths to stdout")
+	public String cat(
+			@CliOption(key = { "", PATH }, mandatory = true, unspecifiedDefaultValue = ".", help = "file name to be shown") final String path) {
+		return shell.cat(path).toString();
+	}
+	
+	@CliCommand(value = PREFIX + "copyFromLocal", help = "Copy single src, or multiple srcs from local file system to the destination file system.")
+	public void copyFromLocal(
+			@CliOption(key = { FROM }, mandatory = true, help = SOURCE_FILE_NAMES) final String source,
+			@CliOption(key = { TO }, mandatory = true, help = DESTINATION_PATH_NAME) final String dest) {
+		shell.copyFromLocal(source, dest);
+	}
+
+	@CliCommand(value = PREFIX + "copyToLocal", help = "Copy files to the local file system.")
+	public void copyToLocal(
+			@CliOption(key = { FROM }, mandatory = true, help = SOURCE_FILE_NAMES) final String source,
+			@CliOption(key = { TO }, mandatory = true, help = DESTINATION_PATH_NAME) final String dest,
+			@CliOption(key = { IGNORECRC }, mandatory = false, specifiedDefaultValue = TRUE, unspecifiedDefaultValue = FALSE, help = "whether ignore CRC") final boolean ignoreCrc,
+			@CliOption(key = { CRC }, mandatory = false, specifiedDefaultValue = TRUE, unspecifiedDefaultValue = FALSE, help = "whether copy CRC") final boolean crc) {
+		shell.copyToLocal(ignoreCrc, crc, source, dest);
+	}
+
+	@CliCommand(value = PREFIX + "expunge", help = "Empty the trash")
+	public void expunge() {
+		shell.expunge();
+	}
+
+	@CliCommand(value = PREFIX + "mv", help = "Move source files to destination in the HDFS")
+	public void mv(
+			@CliOption(key = { FROM }, mandatory = true, help = SOURCE_FILE_NAMES) final String source,
+			@CliOption(key = { TO }, mandatory = true, help = DESTINATION_PATH_NAME) final String dest) {
+		shell.mv(source, dest);
+	}
+	
+	@CliCommand(value = PREFIX + "mkdir", help = "Create a new directory")
+	public void mkdir(
+			@CliOption(key = { "", DIR }, mandatory = true, help = "directory name") final String dir) {
+		shell.mkdir(dir);
+	}
+	
+	private static TableBuilder applySimpleListStyle(TableBuilder builder) {
+		builder
+			.paintBorder(BorderStyle.air, BorderSpecification.INNER_VERTICAL)
+				.fromTopLeft().toBottomRight()
+			.on(CellMatchers.column(4))
+				.addSizer(new AbsoluteWidthSizeConstraints(19))
+				.addFormatter(new TableDateTimeFormatter());
+		return builder;
+	}
+
+	private static class TableDateTimeFormatter implements Formatter {
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+		@Override
+		public String[] format(Object value) {
+			String formatted = "";
+			if (value instanceof Long) {
+				formatted = sdf.format(new Date((Long)value));
+			}
+			return new String[] { formatted };
+		}
+	}
+
+	private static class FileStatusTableModel extends TableModel {
+
+		private final FileStatus[] statuses;
+
+		public FileStatusTableModel(FileStatus[] statuses) {
+			this.statuses = statuses;
+		}
+
+		@Override
+		public int getRowCount() {
+			return statuses.length;
+		}
+
+		@Override
+		public int getColumnCount() {
+			return 6;
+		}
+
+		@Override
+		public Object getValue(int row, int column) {
+			if (column == 0) {
+				return statuses[row].getPermission().toString();
+			}
+			else if (column == 1) {
+				return statuses[row].getOwner();
+			}
+			else if (column == 2) {
+				return statuses[row].getGroup();
+			}
+			else if (column == 3) {
+				return statuses[row].getLen();
+			}
+			else if (column == 4) {
+				return statuses[row].getModificationTime();
+			}
+			else if (column == 5) {
+				return Path.getPathWithoutSchemeAndAuthority(statuses[row].getPath());
+			}
+			else {
+				return "";
+			}
+		}
+	}
+}

--- a/spring-cloud-dataflow-server-yarn-shell/pom.xml
+++ b/spring-cloud-dataflow-server-yarn-shell/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>spring-cloud-dataflow-server-yarn-shell</artifactId>
+	<version>1.0.1.BUILD-SNAPSHOT</version>
+	<packaging>jar</packaging>
+	<name>spring-cloud-dataflow-server-yarn-shell</name>
+	<description>Data Flow Server Shell for Apache Yarn</description>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-dataflow-server-yarn-parent</artifactId>
+		<version>1.0.1.BUILD-SNAPSHOT</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-dataflow-server-yarn-shell-core</artifactId>
+			<version>1.0.1.BUILD-SNAPSHOT</version>
+		</dependency>
+	</dependencies>
+	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>application.yml</include>
+				</includes>
+			</resource>
+		</resources>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/spring-cloud-dataflow-server-yarn-shell/src/main/java/org/springframework/cloud/dataflow/server/yarn/shell/ShellApplication.java
+++ b/spring-cloud-dataflow-server-yarn-shell/src/main/java/org/springframework/cloud/dataflow/server/yarn/shell/ShellApplication.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.dataflow.server.yarn.shell;
+
+import org.springframework.boot.Banner;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.dataflow.shell.EnableDataFlowShell;
+
+/**
+ * Bootstrap class for spring shell.
+ *
+ * @author Janne Valkealahti
+ */
+@EnableDataFlowShell
+@SpringBootApplication
+public class ShellApplication {
+
+	public static void main(String[] args) throws Exception {
+		new SpringApplicationBuilder()
+				.sources(ShellApplication.class )
+				.bannerMode(Banner.Mode.OFF)
+				.web(false)
+				.run(args);
+	}
+}

--- a/spring-cloud-dataflow-server-yarn-shell/src/main/resources/application.yml
+++ b/spring-cloud-dataflow-server-yarn-shell/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+logging:
+  level:
+    org.springframework: WARN
+    org.apache.hadoop: OFF


### PR DESCRIPTION
- Implement basic hdfs commands
- Now using spring hadoop fsShell instead of
  shell from class from hadoop. Configuration
  and setup via spring hadoop auto-config.
- spring-cloud-dataflow-server-yarn-shell-core having
  core shell commands
- spring-cloud-dataflow-server-yarn-shell as a fatjar
  generation project
- Reads fsUri setting from servers.yml
- Fixes #118
