### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/NOTICE
+++ b/NOTICE
@@ -6,7 +6,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
  
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/yarn/YarnDataFlowServerAutoConfiguration.java
+++ b/spring-cloud-dataflow-server-yarn-autoconfig/src/main/java/org/springframework/cloud/dataflow/autoconfigure/yarn/YarnDataFlowServerAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn-client/src/main/java/org/springframework/cloud/dataflow/yarn/client/ClientApplication.java
+++ b/spring-cloud-dataflow-server-yarn-client/src/main/java/org/springframework/cloud/dataflow/yarn/client/ClientApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn-client/src/main/java/org/springframework/cloud/dataflow/yarn/client/YarnPushApplication.java
+++ b/spring-cloud-dataflow-server-yarn-client/src/main/java/org/springframework/cloud/dataflow/yarn/client/YarnPushApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn-client/src/main/java/org/springframework/cloud/dataflow/yarn/client/YarnPushCommand.java
+++ b/spring-cloud-dataflow-server-yarn-client/src/main/java/org/springframework/cloud/dataflow/yarn/client/YarnPushCommand.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/common.xsl
+++ b/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/common.xsl
@@ -9,7 +9,7 @@
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at
 
-   http://www.apache.org/licenses/LICENSE-2.0
+   https://www.apache.org/licenses/LICENSE-2.0
 
  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/epub.xsl
+++ b/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/epub.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/html-multipage.xsl
+++ b/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/html-multipage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/html-singlepage.xsl
+++ b/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/html-singlepage.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/html.xsl
+++ b/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/html.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/pdf.xsl
+++ b/spring-cloud-dataflow-server-yarn-docs/src/main/docbook/xsl/pdf.xsl
@@ -9,7 +9,7 @@ to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an

--- a/spring-cloud-dataflow-server-yarn-h2/src/main/java/org/springframework/cloud/dataflow/yarn/h2/H2ConfigurationProperties.java
+++ b/spring-cloud-dataflow-server-yarn-h2/src/main/java/org/springframework/cloud/dataflow/yarn/h2/H2ConfigurationProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn-h2/src/main/java/org/springframework/cloud/dataflow/yarn/h2/H2ServerApplication.java
+++ b/spring-cloud-dataflow-server-yarn-h2/src/main/java/org/springframework/cloud/dataflow/yarn/h2/H2ServerApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn-h2/src/main/java/org/springframework/cloud/dataflow/yarn/h2/H2ServerConfiguration.java
+++ b/spring-cloud-dataflow-server-yarn-h2/src/main/java/org/springframework/cloud/dataflow/yarn/h2/H2ServerConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn-shell-core/src/main/java/org/springframework/cloud/dataflow/server/yarn/shell/core/HadoopCommands.java
+++ b/spring-cloud-dataflow-server-yarn-shell-core/src/main/java/org/springframework/cloud/dataflow/server/yarn/shell/core/HadoopCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn-shell/src/main/java/org/springframework/cloud/dataflow/server/yarn/shell/ShellApplication.java
+++ b/spring-cloud-dataflow-server-yarn-shell/src/main/java/org/springframework/cloud/dataflow/server/yarn/shell/ShellApplication.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn/src/main/java/org/springframework/cloud/dataflow/server/yarn/YarnDataFlowServer.java
+++ b/spring-cloud-dataflow-server-yarn/src/main/java/org/springframework/cloud/dataflow/server/yarn/YarnDataFlowServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn/src/test/java/org/springframework/cloud/dataflow/server/yarn/TestUtils.java
+++ b/spring-cloud-dataflow-server-yarn/src/test/java/org/springframework/cloud/dataflow/server/yarn/TestUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-dataflow-server-yarn/src/test/java/org/springframework/cloud/dataflow/server/yarn/YarnDataFlowServerTests.java
+++ b/spring-cloud-dataflow-server-yarn/src/test/java/org/springframework/cloud/dataflow/server/yarn/YarnDataFlowServerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/checkstyle/checkstyle-header.txt
+++ b/src/checkstyle/checkstyle-header.txt
@@ -5,7 +5,7 @@
 ^\Q * you may not use this file except in compliance with the License.\E$
 ^\Q * You may obtain a copy of the License at\E$
 ^\Q *\E$
-^\Q *      http://www.apache.org/licenses/LICENSE-2.0\E$
+^\Q *      https://www.apache.org/licenses/LICENSE-2.0\E$
 ^\Q *\E$
 ^\Q * Unless required by applicable law or agreed to in writing, software\E$
 ^\Q * distributed under the License is distributed on an "AS IS" BASIS,\E$


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 21 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).